### PR TITLE
Log requests

### DIFF
--- a/web.go
+++ b/web.go
@@ -7,12 +7,18 @@ import (
 	"os"
 )
 
-// Log the HTTP request
-func logHandler(w http.ResponseWriter, r *http.Request) {
-	log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL)
+// Start an HTTP server listening on $PORT which dispatches to a rootHandler.
+func main() {
+	http.HandleFunc("/", rootHandler)
+	port := os.Getenv("PORT")
+	log.Printf("listening on %v...\n", port)
+	err := http.ListenAndServe(":"+port, nil)
+	if err != nil {
+		panic(err)
+	}
 }
 
-// Write a "Powered by $POWERED_BY" response using the environment variable.
+// Return a "Powered by $POWERED_BY" message using the environment variable.
 func poweredByHandler(w http.ResponseWriter, r *http.Request) {
 	release := os.Getenv("DEIS_RELEASE")
 	if release == "" {
@@ -27,18 +33,12 @@ func poweredByHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Powered by %v\nRelease %v on %v\n", powered, release, hostname)
 }
 
+// Log the HTTP request
+func logHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL)
+}
+
 func rootHandler(w http.ResponseWriter, r *http.Request) {
 	logHandler(w, r)
 	poweredByHandler(w, r)
-}
-
-// Start an HTTP server which dispatches handlers based on URL
-func main() {
-	http.HandleFunc("/", rootHandler)
-	port := os.Getenv("PORT")
-	fmt.Printf("listening on %v...\n", port)
-	err := http.ListenAndServe(":"+port, nil)
-	if err != nil {
-		panic(err)
-	}
 }


### PR DESCRIPTION
I rebased an old PR from our BDFL that adds request logging to example-go:
```console
$ deis logs
2015-04-24T16:32:06UTC deis[api]: matt created initial release
2015-04-24T16:32:55UTC deis[api]: matt deployed 20758f2
2015-04-24T16:32:56UTC deis[api]: matt scaled containers web=1
2015-04-24T16:33:15UTC rugged-duckling[web.1]: 2015/04/24 16:33:15 listening on 5000...
2015-04-24T16:33:20UTC rugged-duckling[web.1]: 2015/04/24 16:33:20 172.17.8.100:56495 GET /
2015-04-24T16:33:20UTC rugged-duckling[web.1]: 2015/04/24 16:33:20 172.17.8.100:56498 GET /favicon.ico
```

Refs #1.