### PR TITLE
chore(.gitignore): hide .env file from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 
 *.exe
 
+.env


### PR DESCRIPTION
The `.env` file contains a user's app configuration for `deis push|pull` and shouldn't be under version control for in this example app.