### PR TITLE
chore(Godeps.json): update to go 1.6

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "github.com/deis/example-go",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.6",
 	"Deps": []
 }


### PR DESCRIPTION
Depends on deis/slugbuilder#27 and deis/deis#4944. This doesn't slow down the build time appreciably AFAICT, compared to go 1.4, but it will silence deprecation warnings in CI jobs.

cc: @vdice