### PR TITLE
fix(Godeps.json): specify packages wildcard

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,6 @@
 {
 	"ImportPath": "github.com/deis/example-go",
 	"GoVersion": "go1.6",
+	"Packages": ["."],
 	"Deps": []
 }


### PR DESCRIPTION
Avoids the `!!` buildpack warning about an implicit "." package by being explicit for `godep`:
```
Starting build... but first, coffee!
-----> Go app detected
-----> Checking Godeps/Godeps.json file.
-----> Installing go1.6.2... done
        !!    Installing package '.' (default)
-----> Running: go install -v -tags heroku .
```